### PR TITLE
System Priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,25 @@ Systems can also be removed dynamically:
 entity_manager.remove_system(movement_system)
 ```
 
+### System Priority
+
+You may want to run systems in a given order, or prioritise some systems over others.
+
+You can enable this behaviour when overriding the `System` constructor. Systems have a priority of 0 by default. This means that when not specified, systems have the lowest possible priority, and are executed in the order they're added to the manager.
+
+Interact with this how you choose. But, for example, if you want to mimic the default constructor, and take a dynamic priority parameter:
+
+```python
+class MovementSystem(System):
+	def __init__(self, entity_manager, priority=0):
+        super().__init__(priority=priority)
+        # ...
+``` 
+
+You can then instantiate your system with a given priority, `movement_system = MovementSystem(priority=1)`
+
+Systems with a higher priority will be executed first by the `EntityManager`.
+
 ### IteratorSystem
 
 Most systems will involve iterating over a `family`. To avoid redundant code, stup provides a handy utility class which will do this for you, called `IteratorSystem`.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Fully functioning and usable for small practice projects. In development. Not re
 * [Component](#component)
     + [Adding and Removing Components](#adding-and-removing-components)
 * [System](#system)
+    + [System Priority](#system-priority)
     + [IteratorSystem](#iteratorsystem)
 * [EntityListener](#entitylistener)
 

--- a/stup/entity_manager.py
+++ b/stup/entity_manager.py
@@ -146,7 +146,7 @@ class EntityManager:
         :return: None
         """
         self._systems.extend(system)
-        self._systems.sort(key=lambda s: s.priority)
+        self._systems.sort(key=lambda s: s.priority, reverse=True)
 
     def remove_system(self, system):
         """Removes given System instance from the Entity Manager.

--- a/stup/entity_manager.py
+++ b/stup/entity_manager.py
@@ -146,6 +146,7 @@ class EntityManager:
         :return: None
         """
         self._systems.extend(system)
+        self._systems.sort(key=lambda s: s.priority)
 
     def remove_system(self, system):
         """Removes given System instance from the Entity Manager.

--- a/stup/system.py
+++ b/stup/system.py
@@ -4,7 +4,10 @@ from .family import Family
 
 class System(ABC):
     """Abstract class for processing Entity instances."""
-    def __init__(self):
+    priority = float("inf")
+
+    def __init__(self, priority=float("inf")):
+        self.priority = priority
         self.family = Family(set())
 
     @abstractmethod

--- a/stup/system.py
+++ b/stup/system.py
@@ -4,11 +4,15 @@ from .family import Family
 
 class System(ABC):
     """Abstract class for processing Entity instances."""
-    priority = float("inf")
+    _priority = float("inf")
 
     def __init__(self, priority=float("inf")):
-        self.priority = priority
+        self._priority = priority
         self.family = Family(set())
+
+    @property
+    def priority(self):
+        return self._priority
 
     @abstractmethod
     def update(self, deltatime):

--- a/stup/system.py
+++ b/stup/system.py
@@ -6,7 +6,7 @@ class System(ABC):
     """Abstract class for processing Entity instances."""
     _priority = float("inf")
 
-    def __init__(self, priority=float("inf")):
+    def __init__(self, priority=0):
         self._priority = priority
         self.family = Family(set())
 

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -38,7 +38,7 @@ def test_system_priority():
     system_3 = UpdateSystem(1)
     entity_manager.add_system(system_3)
     assert entity_manager._systems == [system_3, system_1, system_2]
-    system_4 = UpdateSystem(0)
+    system_4 = UpdateSystem(2)
     entity_manager.add_system(system_4)
     entity_manager.remove_system(system_1)
     assert entity_manager._systems == [system_4, system_3, system_2]

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -27,3 +27,20 @@ def test_update_systems():
     assert system.updates == 0
     entity_manager.update(1)
     assert system.updates == 1
+
+
+def test_system_priority():
+    entity_manager = EntityManager()
+    system_1 = UpdateSystem()
+    system_2 = UpdateSystem()
+    entity_manager.add_system(system_1, system_2)
+    assert entity_manager._systems == [system_1, system_2]
+    system_3 = UpdateSystem(1)
+    entity_manager.add_system(system_3)
+    assert entity_manager._systems == [system_3, system_1, system_2]
+    system_4 = UpdateSystem(0)
+    entity_manager.add_system(system_4)
+    entity_manager.remove_system(system_1)
+    assert entity_manager._systems == [system_4, system_3, system_2]
+    entity_manager.remove_system(system_4)
+    assert entity_manager._systems == [system_3, system_2]


### PR DESCRIPTION
Allows users to specify a priority for `EntityManager` to respect when executing `update()`.